### PR TITLE
Standardize the syntax of phpDoc @var

### DIFF
--- a/src/FactoryGenerator.php
+++ b/src/FactoryGenerator.php
@@ -41,7 +41,7 @@ class FactoryGenerator
             '<?php', self::NL, self::NL, 'use Faker\Generator as Faker;', self::NL,
         ])->when($this->appendFactoryPhpDoc, function (Collection $collection) {
             return $collection->merge([
-                self::NL, '/** @var $factory \Illuminate\Database\Eloquent\Factory */', self::NL,
+                self::NL, '/** @var \Illuminate\Database\Eloquent\Factory $factory */', self::NL,
             ]);
         })->merge([
             self::NL, '$factory->define(\\', get_class($model), '::class, function (Faker $faker) {',


### PR DESCRIPTION
from `/** @var $factory \Illuminate\Database\Eloquent\Factory */`
to   `/** @var \Illuminate\Database\Eloquent\Factory $factory */`

Though some IDEs support both, the standard syntax of phpDoc `@var` tag is supposed to be 

```
@var [“Type”] [$element_name] [<description>]
```

https://docs.phpdoc.org/latest/references/phpdoc/tags/var.html